### PR TITLE
 invalid_markup: Invalid markup when retrieving actions

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
-import NavigationBar from './component_navbar'
-import Content from './component_content'
+
+import NavigationBar from './component_navbar';
+import Content from './component_content';
 
 export default class App extends Component {
   render() {

--- a/src/components/component_card.js
+++ b/src/components/component_card.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import * as actions from '../actions';
+import * as actions from '../actions/index';
 
 class CardComponent extends Component {
   constructor(props) {

--- a/src/components/component_card.js
+++ b/src/components/component_card.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import * as actions from '../actions/index';
+import * as actions from '../actions';
 
 class CardComponent extends Component {
   constructor(props) {

--- a/src/components/component_cart_list.js
+++ b/src/components/component_cart_list.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-class ItemListComponent extends Component {
+class CartComponent extends Component {
   renderItemsIntoAList(items) {
     return items.map((item, index) => {
       if (item.title)
@@ -18,13 +18,38 @@ class ItemListComponent extends Component {
   render() {
     return (
       <div className="component-cart-list">
+
+        <div className="panel panel-default">
+          <div className="panel-heading">
+            <h3 className="panel-title ">
+              Items in the Basket:
+              <div className="float-right">{this.props.itemCounter}</div>
+            </h3>
+          </div>
+          <div className="panel-body">
+            <h5 className="price">
+              Original Price
+              <div className="float-right">${this.props.summurizedPrice} </div>
+            </h5>
+
+            <h5 className="discount">
+              Discount
+              <div className="float-right">
+                - ${this.props.summurizedPrice - this.props.summurizedFinalPrice}
+              </div>
+            </h5>
+            <hr />
+            <h4 className="final-price">
+              Final Price
+              <div className="float-right">${this.props.summurizedFinalPrice}</div>
+            </h4>
+          </div>
+        </div>
+
         <ul className="list-group">
-          <h3>Items in the Basket: {this.props.itemCounter}</h3>
-          <h4 className="price">Price: ${this.props.totalPrice}</h4>
-          <h4 className="discounted-price">Discounted Price: ${this.props.totalDiscountedPrice}</h4>
-          <h5>You got discount of ${this.props.totalPrice - this.props.totalDiscountedPrice}</h5>
           {this.renderItemsIntoAList(this.props.itemsInsideCart)}
         </ul>
+
       </div>
     );
   }
@@ -32,10 +57,10 @@ class ItemListComponent extends Component {
 
 function mapsStateToProps(state) {
   return {
-    itemsInsideCart: state.itemsInsideCart,
-    itemCounter: state.itemCounter,
-    summurizedPrice: state.totalPrices.summurizedPrice,
-    summurizedFinalPrice: state.totalPrices.summurizedFinalPrice
+    itemsInsideCart:  state.itemsInsideCart,
+    itemCounter:      state.itemCounter,
+    summurizedPrice:  state.summurizedPrices.summurizedPrice,
+    summurizedFinalPrice:  state.summurizedPrices.summurizedFinalPrice,
   }
 }
 export default connect(mapsStateToProps)(CartComponent)

--- a/src/components/component_cart_list.js
+++ b/src/components/component_cart_list.js
@@ -29,19 +29,19 @@ class CartComponent extends Component {
           <div className="panel-body">
             <h5 className="price">
               Original Price
-              <div className="float-right">${this.props.summurizedPrice} </div>
+              <div className="float-right">${this.props.summurizedPrices.originalPrice} </div>
             </h5>
 
             <h5 className="discount">
               Discount
               <div className="float-right">
-                - ${this.props.summurizedPrice - this.props.summurizedFinalPrice}
+                - ${this.props.summurizedPrices.originalPrice - this.props.summurizedPrices.finalPrice}
               </div>
             </h5>
             <hr />
             <h4 className="final-price">
               Final Price
-              <div className="float-right">${this.props.summurizedFinalPrice}</div>
+              <div className="float-right">${this.props.summurizedPrices.finalPrice}</div>
             </h4>
           </div>
         </div>
@@ -59,8 +59,7 @@ function mapsStateToProps(state) {
   return {
     itemsInsideCart:  state.itemsInsideCart,
     itemCounter:      state.itemCounter,
-    summurizedPrice:  state.summurizedPrices.summurizedPrice,
-    summurizedFinalPrice:  state.summurizedPrices.summurizedFinalPrice,
+    summurizedPrices:  state.summurizedPrices,
   }
 }
 export default connect(mapsStateToProps)(CartComponent)

--- a/src/components/component_cart_list.js
+++ b/src/components/component_cart_list.js
@@ -34,8 +34,8 @@ function mapsStateToProps(state) {
   return {
     itemsInsideCart: state.itemsInsideCart,
     itemCounter: state.itemCounter,
-    totalPrice: state.totalPrices.totalPrice,
-    totalDiscountedPrice: state.totalPrices.totalDiscountedPrice
+    summurizedPrice: state.totalPrices.summurizedPrice,
+    summurizedFinalPrice: state.totalPrices.summurizedFinalPrice
   }
 }
-export default connect(mapsStateToProps)(ItemListComponent)
+export default connect(mapsStateToProps)(CartComponent)

--- a/src/components/component_cart_list.js
+++ b/src/components/component_cart_list.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux'
+import { connect } from 'react-redux';
 
 class ItemListComponent extends Component {
   renderItemsIntoAList(items) {

--- a/src/components/component_content.js
+++ b/src/components/component_content.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux'
-import Card from './component_card'
-import CartList from './component_cart_list'
+import { connect } from 'react-redux';
+
+import Card from './component_card';
+import CartList from './component_cart_list';
 
 class ContentComponent extends Component {
   renderCards(items) {

--- a/src/components/component_navbar.js
+++ b/src/components/component_navbar.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux'
+import { connect } from 'react-redux';
 
 class NavigationBar extends Component {
   render() {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -9,7 +9,7 @@ const rootReducer = combineReducers({
   items: DummyDataReducer,
   itemsInsideCart: AddToCartReducer,
   itemCounter: ItemCounterReducer,
-  totalPrices: TotalPriceReducer
+  summurizedPrices: TotalPriceReducer
 });
 
 export default rootReducer;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,9 +1,9 @@
 import { combineReducers } from 'redux';
 
-import DummyDataReducer from './dummy_items_data'
-import AddToCartReducer from './reducer_add_item_to_cart'
+import DummyDataReducer   from './dummy_items_data'
+import AddToCartReducer   from './reducer_add_item_to_cart'
 import ItemCounterReducer from './reducer_item_counter'
-import TotalPriceReducer from './reducer_total_price'
+import TotalPriceReducer  from './reducer_total_price'
 
 const rootReducer = combineReducers({
   items: DummyDataReducer,

--- a/src/reducers/reducer_add_item_to_cart.js
+++ b/src/reducers/reducer_add_item_to_cart.js
@@ -1,4 +1,4 @@
-import { ADD_ITEM_TO_CART } from '../actions/types'
+import { ADD_ITEM_TO_CART } from '../actions/types';
 
 const INITIAL_STATE = [{ title: null }];
 

--- a/src/reducers/reducer_item_counter.js
+++ b/src/reducers/reducer_item_counter.js
@@ -1,4 +1,4 @@
-import { CART_ITEM_COUNTER } from '../actions/types'
+import { CART_ITEM_COUNTER } from '../actions/types';
 
 const INITIAL_STATE = 0;
 

--- a/src/reducers/reducer_total_price.js
+++ b/src/reducers/reducer_total_price.js
@@ -1,4 +1,4 @@
-import { TOTAL_PRICE } from '../actions/types'
+import { TOTAL_PRICE } from '../actions/types';
 
 const INITIAL_STATE = { totalPrice: 0, totalDiscountedPrice: 0 };
 

--- a/src/reducers/reducer_total_price.js
+++ b/src/reducers/reducer_total_price.js
@@ -1,13 +1,13 @@
 import { TOTAL_PRICE } from '../actions/types';
 
-const INITIAL_STATE = { summurizedPrice: 0, summurizedFinalPrice: 0 };
+const INITIAL_STATE = { originalPrice: 0, finalPrice: 0 };
 
 export default function (state = INITIAL_STATE, action) {
   switch (action.type) {
     case TOTAL_PRICE:
       return {
-        summurizedPrice: state.summurizedPrice + action.payload.totalPrice,
-        summurizedFinalPrice: state.summurizedFinalPrice + action.payload.discountedPrice
+        originalPrice: state.originalPrice + action.payload.totalPrice,
+        finalPrice: state.finalPrice + action.payload.discountedPrice
       };
   }
   return state

--- a/src/reducers/reducer_total_price.js
+++ b/src/reducers/reducer_total_price.js
@@ -1,13 +1,13 @@
 import { TOTAL_PRICE } from '../actions/types';
 
-const INITIAL_STATE = { totalPrice: 0, totalDiscountedPrice: 0 };
+const INITIAL_STATE = { summurizedPrice: 0, summurizedFinalPrice: 0 };
 
 export default function (state = INITIAL_STATE, action) {
   switch (action.type) {
     case TOTAL_PRICE:
       return {
-        totalPrice: state.totalPrice + action.payload.totalPrice,
-        totalDiscountedPrice: state.totalDiscountedPrice + action.payload.discountedPrice
+        summurizedPrice: state.summurizedPrice + action.payload.totalPrice,
+        summurizedFinalPrice: state.summurizedFinalPrice + action.payload.discountedPrice
       };
   }
   return state

--- a/style/style.css
+++ b/style/style.css
@@ -12,3 +12,7 @@
     margin-bottom: 2.3em !important;
     left: 2em;
 }
+
+.float-right{
+    float: right;
+}

--- a/test/components/component_cart_list_test.js
+++ b/test/components/component_cart_list_test.js
@@ -8,8 +8,8 @@ describe('ComponentCartList', () => {
       itemsInsideCart: [{ title: 'a title' }, { title: 'another title' }, { title: 'yet another title' }],
       itemCounter: 3,
       summurizedPrices: {
-        summurizedPrice: 50,
-        summurizedFinalPrice: 40
+        originalPrice: 50,
+        finalPrice: 40
       }
     };
     component = renderComponent(ComponentCartList, null, props);

--- a/test/components/component_cart_list_test.js
+++ b/test/components/component_cart_list_test.js
@@ -7,9 +7,9 @@ describe('ComponentCartList', () => {
     const props = {
       itemsInsideCart: [{ title: 'a title' }, { title: 'another title' }, { title: 'yet another title' }],
       itemCounter: 3,
-      totalPrices: {
-        totalPrice: 50,
-        totalDiscountedPrice: 40
+      summurizedPrices: {
+        summurizedPrice: 50,
+        summurizedFinalPrice: 40
       }
     };
     component = renderComponent(ComponentCartList, null, props);
@@ -23,20 +23,21 @@ describe('ComponentCartList', () => {
       it('list-group', () => {
         expect(component.find('.list-group')).to.exist;
       });
+      it('panel', () => {
+        expect(component.find('.panel')).to.exist;
+        expect(component.find('.panel-default')).to.exist;
+      });
     });
 
     describe('must have element', () => {
       it('ul', () => {
         expect(component.find('ul')).to.exist;
       });
-      it('h3', () => {
-        expect(component.find('h3')).to.exist;
+      it('h5', () => {
+        expect(component.find('h5')).to.exist;
       });
       it('h4', () => {
         expect(component.find('h4')).to.exist;
-      });
-      it('h5', () => {
-        expect(component.find('h5')).to.exist;
       });
     });
 
@@ -45,16 +46,16 @@ describe('ComponentCartList', () => {
         expect(component.find('li').length).to.equal(3);
       });
       it('item counter works correctly', () => {
-        expect(component.find('h3')).to.contain('Items in the Basket: 3');
-      });
-      it('gets discounted correctly', () => {
-        expect(component.find('h5')).to.contain('You got discount of $10');
+        expect(component.find('h3')).to.contain('Items in the Basket:3');
       });
       it('price is correct', () => {
-        expect(component.find('.price')).to.contain('Price: $50');
+        expect(component.find('.price')).to.contain('Original Price$50');
       });
-      it('discounted price is correct', () => {
-        expect(component.find('.discounted-price')).to.contain('Discounted Price: $40');
+      it('discount is correct', () => {
+        expect(component.find('.discount')).to.contain('Discount- $10');
+      });
+      it('final price is correct', () => {
+        expect(component.find('.final-price')).to.contain('Final Price$40');
       });
     });
   });

--- a/test/reducers/reducer_total_price_test.js
+++ b/test/reducers/reducer_total_price_test.js
@@ -4,12 +4,12 @@ import { TOTAL_PRICE } from '../../src/actions/types'
 
 describe('addItemToCartReducer', () => {
   it('handles unknown action type', () => {
-    expect(totalPriceReducer(undefined, {})).to.be.eql({ summurizedPrice: 0, summurizedFinalPrice: 0 })
+    expect(totalPriceReducer(undefined, {})).to.be.eql({ originalPrice: 0, finalPrice: 0 })
   });
 
   it('handles the action it supposed to', () => {
     const acton = { type: TOTAL_PRICE, payload: { totalPrice: 50, discountedPrice: 40 } };
-    expect(totalPriceReducer({ summurizedPrice: 0, summurizedFinalPrice: 0 }, acton))
-      .to.be.eql({ summurizedPrice: 50, summurizedFinalPrice: 40 })
+    expect(totalPriceReducer({ originalPrice: 0, finalPrice: 0 }, acton))
+      .to.be.eql({ originalPrice: 50, finalPrice: 40 })
   })
 });

--- a/test/reducers/reducer_total_price_test.js
+++ b/test/reducers/reducer_total_price_test.js
@@ -4,12 +4,12 @@ import { TOTAL_PRICE } from '../../src/actions/types'
 
 describe('addItemToCartReducer', () => {
   it('handles unknown action type', () => {
-    expect(totalPriceReducer(undefined, {})).to.be.eql({ totalPrice: 0, totalDiscountedPrice: 0 })
+    expect(totalPriceReducer(undefined, {})).to.be.eql({ summurizedPrice: 0, summurizedFinalPrice: 0 })
   });
 
   it('handles the action it supposed to', () => {
     const acton = { type: TOTAL_PRICE, payload: { totalPrice: 50, discountedPrice: 40 } };
-    expect(totalPriceReducer({ totalPrice: 0, totalDiscountedPrice: 0 }, acton))
-      .to.be.eql({ totalPrice: 50, totalDiscountedPrice: 40 })
+    expect(totalPriceReducer({ summurizedPrice: 0, summurizedFinalPrice: 0 }, acton))
+      .to.be.eql({ summurizedPrice: 50, summurizedFinalPrice: 40 })
   })
 });


### PR DESCRIPTION
Hey Jereth, 

> invalid_markup: fixes invalid markup

I fixed this invalid markup, can you please check if this is the one that you had in mind?
To be honest I dont think this would be the one because 
`import * as actions from '../actions';`
is equlevant to 
`import * as actions from '../actions/index';`
as the first one looks for an index file if it exists and imports it,
but I couldnt see anything else that could be weird.

Waiting for your feedback.
		
